### PR TITLE
Support materialize css v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ $ rails generate simple_form:materialize:install
 ```
 
 ### Step 3:
+Find your newly generated initializer at `config/initializers/simple_form_materialize.rb`. Depending on the version of `materialize-css` that you are using you may need to comment/uncomment certain sections.
+
+
+### Step 4:
 Import Materialize Form javascript in `app/assets/javascripts/application.js`:
 
 ```

--- a/app/assets/javascripts/materialize-form.js
+++ b/app/assets/javascripts/materialize-form.js
@@ -17,10 +17,17 @@ window.materializeForm = {
     $('input[type=checkbox]').addClass('filled-in')
   },
   initDate: function() {
-    $('input.date').pickadate({
-      selectMonths: true,
-      selectYears: 100
-    });
+    if (typeof $('input.date').pickadate === "function") {
+      $('input.date').pickadate({
+        selectMonths: true,
+        selectYears: 100
+      });
+    } else {
+      $('input.date').datepicker({
+        selectMonths: true,
+        selectYears: 100
+      });
+    }
   }
 }
 

--- a/app/assets/javascripts/materialize-form.js
+++ b/app/assets/javascripts/materialize-form.js
@@ -6,7 +6,12 @@ window.materializeForm = {
   },
   initSelect: function() {
     $('select[multiple="multiple"] option[value=""]').attr('disabled', true)
-    $('select').material_select()
+    if (typeof $('select').material_select === "function") {
+      $('select').material_select()
+    } else {
+      $('select').formSelect()
+    }
+
   },
   initCheckbox: function() {
     $('input[type=checkbox]').addClass('filled-in')

--- a/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
+++ b/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
@@ -36,10 +36,17 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
 
+    # Uncomment if using materialize-css version < 1
+    # b.use :input
+    # b.use :label
+    #
+
+    # Uncomment if using materialize-css version >= 1
     b.wrapper tag: 'label' do |ba|
       ba.use :input
       ba.use :tag, tag: 'span', text: :label_text
     end
+    #
 
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
     b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }

--- a/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
+++ b/lib/generators/simple_form/materialize/templates/config/initializers/simple_form_materialize.rb
@@ -26,7 +26,7 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :input, class: 'materialize-textarea' 
+    b.use :input, class: 'materialize-textarea'
     b.use :label
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
     b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
@@ -36,8 +36,11 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
 
-    b.use :input
-    b.use :label
+    b.wrapper tag: 'label' do |ba|
+      ba.use :input
+      ba.use :tag, tag: 'span', text: :label_text
+    end
+
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
     b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
   end
@@ -47,11 +50,11 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     b.use :label
-    b.wrapper tag: 'label' do |ba| 
+    b.wrapper tag: 'label' do |ba|
       ba.use :input
       ba.use :tag, tag: 'span', class: 'lever'
     end
-    
+
     b.use :error, wrap_with: { tag: 'small', class: 'error-block red-text text-darken-1' }
     b.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
   end
@@ -68,7 +71,7 @@ SimpleForm.setup do |config|
   config.wrappers :materialize_file_input, tag: 'div', class: 'file-field input-field col', error_class: 'has-error' do |b|
     b.use :html5
 
-    b.wrapper tag: :div, class: 'btn' do |ba| 
+    b.wrapper tag: :div, class: 'btn' do |ba|
       ba.use :tag, tag: :span, text: :label_text
       ba.use :input
     end
@@ -83,8 +86,8 @@ SimpleForm.setup do |config|
 
   config.wrappers :materialize_multiple_file_input, tag: 'div', class: 'file-field input-field col', error_class: 'has-error' do |b|
     b.use :html5
-    
-    b.wrapper tag: :div, class: 'btn' do |ba| 
+
+    b.wrapper tag: :div, class: 'btn' do |ba|
       ba.use :tag, tag: :span, text: :label_text
       ba.use :input, multiple: true
     end


### PR DESCRIPTION
I just upgraded to the latest version of [`materialize-css 1.0.0-rc.1 `](https://github.com/Dogfalo/materialize/tree/1.0.0-rc.1), and there are a few issues that need to be resolved.

- [x] the method `material_select()` is now `formSelect()`. _I added support for it as well as made it backwards compatible_
- [x] the method `pickadate()` is now `datepicker()`. _I added support for it as well as made it backwards compatible_
- [x] Make sure that all other form fields work